### PR TITLE
use title and message notification parameters on Android

### DIFF
--- a/flutter_screen_recording/android/src/main/kotlin/com/isvisoft/flutter_screen_recording/FlutterScreenRecordingPlugin.kt
+++ b/flutter_screen_recording/android/src/main/kotlin/com/isvisoft/flutter_screen_recording/FlutterScreenRecordingPlugin.kt
@@ -79,7 +79,15 @@ class FlutterScreenRecordingPlugin(
         if (call.method == "startRecordScreen") {
             try {
                 _result = result
-                ForegroundService.startService(registrar.context(), "Your screen is being recorded")
+                var title = call.argument<String?>("title")
+                var message = call.argument<String?>("message")
+                if (title == null || title == "") {
+                    title = "Your screen is being recorded";
+                }
+                if (message == null || message == "") {
+                    message = "Your screen is being recorded"
+                }
+                ForegroundService.startService(registrar.context(), title, message)
                 mProjectionManager = registrar.context().applicationContext.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager?
 
                 val metrics = DisplayMetrics()

--- a/flutter_screen_recording/android/src/main/kotlin/com/isvisoft/flutter_screen_recording/ForegroundService.kt
+++ b/flutter_screen_recording/android/src/main/kotlin/com/isvisoft/flutter_screen_recording/ForegroundService.kt
@@ -16,9 +16,10 @@ import com.isvisoft.flutter_screen_recording.R
 class ForegroundService : Service() {
     private val CHANNEL_ID = "ForegroundService Kotlin"
     companion object {
-        fun startService(context: Context, message: String) {
+        fun startService(context: Context, title: String, message: String) {
             val startIntent = Intent(context, ForegroundService::class.java)
-            startIntent.putExtra("inputExtra", message)
+            startIntent.putExtra("messageExtra", message)
+            startIntent.putExtra("titleExtra", title)
             ContextCompat.startForegroundService(context, startIntent)
         }
         fun stopService(context: Context) {
@@ -28,7 +29,14 @@ class ForegroundService : Service() {
     }
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 
-        val input = intent?.getStringExtra("inputExtra")
+        var title = intent?.getStringExtra("titleExtra")
+        if (title == null) {
+            title = "Flutter Screen Recording";
+        }
+        var message = intent?.getStringExtra("messageExtra")
+        if (message == null) {
+            message = ""
+        }
 
         createNotificationChannel()
         val notificationIntent = Intent(this, FlutterScreenRecordingPlugin::class.java)
@@ -38,8 +46,8 @@ class ForegroundService : Service() {
                 0, notificationIntent, PendingIntent.FLAG_MUTABLE
         )
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-                .setContentTitle("Flutter Screen Recording")
-                .setContentText(input)
+                .setContentTitle(title)
+                .setContentText(message)
                 .setSmallIcon(R.drawable.icon)
                 .setContentIntent(pendingIntent)
                 .build()

--- a/flutter_screen_recording/lib/flutter_screen_recording.dart
+++ b/flutter_screen_recording/lib/flutter_screen_recording.dart
@@ -15,14 +15,22 @@ class FlutterScreenRecording {
     }
 
     await _maybeStartFGS(titleNotification, messageNotification);
-    final bool start = await FlutterScreenRecordingPlatform.instance.startRecordScreen(name);
+    final bool start = await FlutterScreenRecordingPlatform.instance.startRecordScreen(
+      name,
+      notificationTitle: titleNotification, 
+      notificationMessage: messageNotification,
+    );
 
     return start;
   }
 
   static Future<bool> startRecordScreenAndAudio(String name, {String? titleNotification, String? messageNotification}) async {
     //await _maybeStartFGS(titleNotification, messageNotification);
-    final bool start = await FlutterScreenRecordingPlatform.instance.startRecordScreenAndAudio(name);
+    final bool start = await FlutterScreenRecordingPlatform.instance.startRecordScreenAndAudio(
+      name,
+      notificationTitle: titleNotification ?? "",
+      notificationMessage: messageNotification ?? "",
+    );
     return start;
   }
 

--- a/flutter_screen_recording_platform_interface/lib/flutter_screen_recording_platform_interface.dart
+++ b/flutter_screen_recording_platform_interface/lib/flutter_screen_recording_platform_interface.dart
@@ -27,11 +27,19 @@ abstract class FlutterScreenRecordingPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<bool> startRecordScreen(String name) {
+  Future<bool> startRecordScreen(
+    String name, {
+    String notificationTitle = "",
+    String notificationMessage = "",
+  }) {
     throw UnimplementedError();
   }
 
-  Future<bool> startRecordScreenAndAudio(String name) {
+  Future<bool> startRecordScreenAndAudio(
+    String name, {
+    String notificationTitle = "",
+    String notificationMessage = "",
+  }) {
     throw UnimplementedError();
   }
 

--- a/flutter_screen_recording_platform_interface/lib/method_channel_flutter_screen_recording.dart
+++ b/flutter_screen_recording_platform_interface/lib/method_channel_flutter_screen_recording.dart
@@ -9,15 +9,31 @@ class MethodChannelFlutterScreenRecording
   static const MethodChannel _channel =
       const MethodChannel('flutter_screen_recording');
 
-  Future<bool> startRecordScreen(String name) async {
-    final bool start = await _channel
-        .invokeMethod('startRecordScreen', {"name": name, "audio": false});
+  Future<bool> startRecordScreen(
+    String name, {
+    String notificationTitle = "",
+    String notificationMessage = "",
+  }) async {
+    final bool start = await _channel.invokeMethod('startRecordScreen', {
+      "name": name,
+      "audio": false,
+      "title": notificationTitle,
+      "message": notificationMessage,
+    });
     return start;
   }
 
-  Future<bool> startRecordScreenAndAudio(String name) async {
-    final bool start = await _channel
-        .invokeMethod('startRecordScreen', {"name": name, "audio": true});
+  Future<bool> startRecordScreenAndAudio(
+    String name, {
+    String notificationTitle = "",
+    String notificationMessage = "",
+  }) async {
+    final bool start = await _channel.invokeMethod('startRecordScreen', {
+      "name": name,
+      "audio": true,
+      "title": notificationTitle,
+      "message": notificationMessage,
+    });
     return start;
   }
 

--- a/flutter_screen_recording_web/lib/flutter_screen_recording_web.dart
+++ b/flutter_screen_recording_web/lib/flutter_screen_recording_web.dart
@@ -21,12 +21,20 @@ class WebFlutterScreenRecording extends FlutterScreenRecordingPlatform {
   }
 
   @override
-  Future<bool> startRecordScreen(String name) async {
+  Future<bool> startRecordScreen(
+    String name, {
+    String notificationTitle = "",
+    String notificationMessage = "",
+  }) async {
     return _record(name, true, false);
   }
 
   @override
-  Future<bool> startRecordScreenAndAudio(String name) async {
+  Future<bool> startRecordScreenAndAudio(
+    String name, {
+    String notificationTitle = "",
+    String notificationMessage = "",
+  }) async {
     return _record(name, true, true);
   }
 


### PR DESCRIPTION
Currently the title and message notification parameters aren't being used on Android. Leading only to "Flutter Screen Recording" being displayed. This PR fixes that.